### PR TITLE
Switch initial strata counter value?

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -321,7 +321,7 @@ class init_tools(object):
         """Creates sparse array to store stratigraphy data."""
         if self.save_strata:
 
-            self.strata_counter = 0
+            self.strata_counter = 1
 
             self.n_steps = 5 * self.save_dt
 


### PR DESCRIPTION
Break in the docs was occurring in the `10min.rst` quickstart guide. The error was occurring when `delta.finalize()` was being called after 2 iterations had been run.

Traceback on the error:

```
File "guides/10min.rst", line 24, in default
Failed example:
    delta.finalize()
Exception raised:
    Traceback (most recent call last):
      File "/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest default[1]>", line 1, in <module>
        delta.finalize()
      File "/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pyDeltaRCM-1.1.0-py3.8.egg/pyDeltaRCM/model.py", line 120, in finalize
        self.output_strata()
      File "/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pyDeltaRCM-1.1.0-py3.8.egg/pyDeltaRCM/deltaRCM_tools.py", line 322, in output_strata
        total_strata_age = self.output_netcdf.createDimension(
      File "netCDF4/_netCDF4.pyx", line 2562, in netCDF4._netCDF4.Dataset.createDimension
      File "netCDF4/_netCDF4.pyx", line 3370, in netCDF4._netCDF4.Dimension.__init__
      File "netCDF4/_netCDF4.pyx", line 1887, in netCDF4._netCDF4._ensure_nc_success
    RuntimeError: NetCDF: NC_UNLIMITED size already in use
```

This came down to `shape` (defined [here](https://github.com/elbeejay/pyDeltaRCM_WMT/blob/c961559d606bb11cc7432c93d4b4929e79daa41c/pyDeltaRCM/deltaRCM_tools.py#L316)) as having the dimensions (800, 0). We define `self.strata_eta` two lines before that by using `self.strata_eta` and `self.strata_counter`. The issue was that `self.strata_counter` is initialized to 0, so then the second index of `shape` became 0 too. So we can fix this error by initializing `self.strata_counter` as 1, but I am not sure if this throws off any of the other stratigraphy stuff... so I don't consider this a totally "safe" fix (even though all of our tests pass).