### PR TITLE
fix actions badge pointer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pyDeltaRCM_WMT
 **************
 
-.. image:: https://github.com/DeltaRCM/pyDeltaRCM_WMT/workflows/actions/badge.svg
+.. image:: https://github.com/DeltaRCM/pyDeltaRCM_WMT/workflows/build/badge.svg
     :target: https://github.com/DeltaRCM/pyDeltaRCM_WMT/actions
 
 .. image:: https://codecov.io/gh/DeltaRCM/pyDeltaRCM_WMT/branch/develop/graph/badge.svg


### PR DESCRIPTION
image was from an Actions workflow we don't use anymore. The good news was the last build on the workflow as a success, so we always had a green badge :laughing: